### PR TITLE
Added a gitignore and a README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,77 @@
+# Compiled class file
+*.class
+**/*.class
+
+# Log file
 *.log
-*.bak
 **/*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# Gradle build files
+.gradle/*
+
+# Eclipse wants to add this
+/.gradle/
+
+# Build files
+*/build/*
+
+# Eclipse files
+.project
+/.project
+.classpath
+/.classpath
+*.prefs
+/*.prefs
+
+# backup files
+*.bak
 **/*.bak
+**/*.bak.*
+
+# Python files
+*.idea
+*.pyc
+__pycache__/
+
+# duplicated files
+* - Copy*
+**/* - Copy*
+
+# DSS files
+*.dss
+**/*.dss
+
+# pyinstaller files
+dist/
+build/
+*.spec
+
+# compiled Jasper files
+*.jasper
+jasperC/**
+jasperC/
+jasperC/*.jasper
+
+# created by the reporting
+Images/**
+CSVData/**
+Datasources/USBRAutomatedReportOutput.xml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Sacramento WTMP Scripts
+The HEC-WAT scripts folder for the Sacramento River within the Bureau of Reclamation (USBR) Water Temperature Modeling Platform (WTMP).
+This repository is a dependency of the Sacramento WTMP Study repository.
+These scripts are called at different points in the WTMP workflow.
+These scripts are all in Jython, the implementation of Python in Java.
+
+## W2 files
+### Forecast
+### Hindcast
+### Planning
+### Shared or not specified
+* Lewiston-W2.py
+* OutputLink_W2-Lewiston-Downstream_SacTrn.py
+* OutputLink_W2-Trinity-W2-Lewiston_SacTrn.py
+* OutputLink_W2-Whiskeytown-Downstream_SacTrn.py
+* Pre-Process_W2_5-Res_Prescribed_SacTrn.py
+  * The pre-processing script for W2
+* Pre-Process_W2_5-Res_Prescribed_V45_SacTrn.py
+  * The pre-processing script for W2
+* Pre-Process_W2_5-Res_SacTrn.py
+  * The pre-processing script for W2
+* w2_shasta_TCD_flow.py
+
+## ResSim files
+### Forecast
+### Hindcast
+### Planning
+### Shared or not specified
+* Lewiston_Tunnel_AddHeating_5ResFcst.py
+* Lewiston_Tunnel_AddHeating_5ResTemp.py
+* Post-Process_ResSim_SacTrn.py
+  * The post-processing script for ResSim
+* Post-Process_ResSim_SacTrnNS.py
+  * The post-processing script for ResSim
+* Post-Process_ResSim_SacTrnPO.py
+  * The post-processing script for ResSim
+* Post-Process_ResSim_SacTrnRv.py
+  * The post-processing script for ResSim
+* Pre-Process_ResSim_SacTrn.py
+  * The pre-processing script for ResSim
+* Pre-Process_ResSim_SacTrnPO.py
+  * The pre-processing script for ResSim
+
+## Shared files between W2 and ResSim
+These files contain various function that are shared by different models.
+* Acc_Dep_ResSim_SacTrn.py
+* AddTwoTimeSeries.py
+* BoundaryFixes.py
+* ClearCreekHeating.py
+* Combine_2_DSS_Recs.py
+* create_balance_flow_jython.py
+* DMS_preprocess.py
+* DSS_Tools.py
+* equilibrium_temp.py
+* flowweightaverage.py
+* Simple_DSS_Functions.py
+* SpringCreekTunnelHeating.py
+* Trinity2Lewiston.py
+* tz_offset.py
+* UpperSac_RSS_CombineTemp.py
+
+### Forecast
+Forecast_preprocess.py
+
+## Dependencies
+There are dependencies that come from the WAT and from external locations that must be brought in. 
+
+- hec
+  - hec.heclib
+  - hec.io
+  - hec.hecmath
+- rma
+  - com.rma
+  - rma.util.RMAConst
+
+## Usage
+### Usage withing the build process
+To be added later.
+
+### Post build implementation
+After making any desired changes to the code, files must be replaced in the scripts folder in a WTMP Sacramento Study folder. 
+Scripts will be triggered as various points of the modeling workflow.


### PR DESCRIPTION
This repository previously had no README and gitignore that did not contain everything that should be excluded.

Added to the gitignore to include files that may get created by Java, Python, Jasper, gradle, and other files that we would not want in the repository. This gitignore combined gitignores from other repositories that are involved in the build process.

README now has a brief description of this repository as well as details on files and usage. Files were grouped together by what model uses them. Some files are not clear what they are used for so those are left as shared/not specified. Instructions for usage was also added. Any sections with no information should be filled in later.

This should make this repository easier to work with and reduce the number of unwanted files.