### PR TITLE
Shasta Target Temperature Unit Conversion

### DIFF
--- a/DMS_preprocess.py
+++ b/DMS_preprocess.py
@@ -16,6 +16,8 @@ from com.rma.io import DssFileManagerImpl
 from com.rma.model import Project
 #import hec.hecmath.TimeSeriesMath as tsmath
 
+sys.path.append(os.path.join(Project.getCurrentProject().getWorkspacePath(), "scripts"))
+
 from com.rma.io import DssFileManagerImpl
 from java.util import TimeZone
 
@@ -633,6 +635,9 @@ def preprocess_W2_5Res(currentAlternative, computeOptions):
     met_dss_file = os.path.join(shared_dir,'DMS_SacTrnMet.dss')
     fix_DMS_types_units(met_dss_file)
 
+    # ressim can't handle different units under model linking
+    standardize_bc_temp_water_to_C(hydro_dss,output_dss_file)
+
     DSS_Tools.create_constant_dss_rec(currentAlternative, rtw, output_dss_file, constant=0.001, what='flow', 
                         dss_type='PER-AVER', period='1DAY',cpart='TinyFlow',fpart='TinyFlow')
     DSS_Tools.create_constant_dss_rec(currentAlternative, rtw, output_dss_file, constant=0.001, what='flow', 
@@ -675,8 +680,7 @@ def preprocess_ResSim_5Res(currentAlternative, computeOptions):
     fix_DMS_types_units(hydro_dss)
     met_dss_file = os.path.join(shared_dir,'DMS_SacTrnMet.dss')
     fix_DMS_types_units(met_dss_file)
-    # ressim can't handle different units under model linking
-    standardize_bc_temp_water_to_C(hydro_dss,output_dss_file)
+    
 
     DSS_Tools.create_constant_dss_rec(currentAlternative, rtw, output_dss_file, constant=0.0, what='flow', 
                         dss_type='PER-AVER', period='1DAY',cpart='ZEROS',fpart='ZEROS')

--- a/DSS_Tools.py
+++ b/DSS_Tools.py
@@ -46,12 +46,12 @@ def copy_dss_ts(dss_rec,new_fpart=None,new_dss_rec=None,
         dss_rec_out = '/'.join(rec_parts)    
 
     # fix some terrible units along the way
-    if tsc.units.lower() == 'degc':
+    if tsc.units.lower() in ('degc','c'):
         tsc.units = 'C'
-    elif tsc.units.lower() == 'degf':
+    elif tsc.units.lower() in ('degf','f'):
         tsc.units = 'F'
-
-    if tsc.units.lower() == 'f' and checkMakeCelsius:
+	
+    if tsc.units.lower() in ('f','degf') or checkMakeCelsius:
         T_values = tsc.values
         for i, TT in enumerate(T_values):
             T_values[i] = (TT-32.0)*5.0/9.0

--- a/Forecast_preprocess.py
+++ b/Forecast_preprocess.py
@@ -15,6 +15,7 @@ import os, sys, csv, calendar
 from com.rma.io import DssFileManagerImpl
 from com.rma.model import Project
 #import hec.hecmath.TimeSeriesMath as tsmath
+sys.path.append(os.path.join(Project.getCurrentProject().getWorkspacePath(), "scripts"))
 
 import DSS_Tools
 reload(DSS_Tools)
@@ -564,7 +565,7 @@ def upstream_target(forecastDSS,rtw,downstreamTT_rec,eqTemp_rec,kesFlow_rec,sppF
     dtt = DSS_Tools.hectime_to_datetime(tsc)
     downstreamTT = tsc.values
     TT_units = str(tsc.units)
-    if TT_units.lower() == 'f' or TT_units.lower() == 'degF':
+    if TT_units.lower() == 'f' or TT_units.lower() == 'degf':
         for i, TT in enumerate(downstreamTT):
             downstreamTT[i] = (TT-32.0)*5.0/9.0
         tsc.units = 'C'    
@@ -675,9 +676,11 @@ def forecast_data_preprocess_W2_5Res(currentAlternative, computeOptions):
 
     TT_rec = "/USBR/SHASTA/TEMP-WATER-TARGET//1Day/SACTRN_BC_SCRIPT/"
     TT_W2_rec = "/USBR/SHASTA/TEMP-WATER-TARGET-W2-UPSTREAM//1Day/SACTRN_BC_SCRIPT/"
+    
     if location == 0: 
         # @ Shasta Dam, use exact TT
         DSS_Tools.copy_dss_ts(TT_rec,new_dss_rec=TT_W2_rec,dss_file_path=forecast_dss,checkMakeCelsius=True)
+		
     else:
         upstream_target(forecast_dss,rtw,
                         "/USBR/SHASTA/TEMP-WATER-TARGET//1Day/SACTRN_BC_SCRIPT/",


### PR DESCRIPTION
Fixes #5 

Issue: The W2-ResSim model for Sacramento produces different results if the units of the target temperature is in degree Celsius or Fahrenheit. 
 
Solution: this is only a partial fix. The added scripts in Forecast_preprocess.py, DSS_Tools.py, and DMS_preprocess.py check whether the target temperatures are in degree Celsius ("c" or "degc") or in degree Fahrenheit ("f" or "degf"). If the target temperatures are in degree Fahrenheit, then apply the degree fahrenheit to Celsius conversion equation.
